### PR TITLE
Allow to ignore whitespaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,13 @@ so this will work as expected:
   except ValueError:
       pass
 
+You can specify ``strict=False`` to say the library to be tolerant to whitespaces:
+
+.. code-block:: python
+
+  >>> parsed = datauri.parse(' data: text/plain; base64, YW55IGNhcm 5hbCBwbGVhcw ')
+
+
 In addition to parsing a string, this library can also discover (and
 directly parse) any ``data:`` URIs found in a larger string:
 

--- a/datauri/datauri.py
+++ b/datauri/datauri.py
@@ -47,7 +47,7 @@ class ParsedDataURI:
         return hash((self.media_type, self.data))
 
 
-def parse(uri):
+def parse(uri, strict=True):
     """
     Parse a 'data:' URI.
 
@@ -58,10 +58,17 @@ def parse(uri):
     s = uri[5:]
     if not s or ',' not in s:
         raise DataURIError('invalid data uri')
+
     media_type, _, raw_data = s.partition(',')
-    is_base64_encoded = media_type.endswith(';base64')
-    if is_base64_encoded:
+    # https://github.com/eclecticiq/python-data-uri/issues/7
+    if not strict:
+        media_type = ''.join(media_type.split())  # remove all spaces
+
+    if media_type.endswith(';base64'):
         media_type = media_type[:-7]
+        # https://github.com/eclecticiq/python-data-uri/issues/7
+        if not strict:
+            raw_data = ''.join(raw_data.split())  # remove all spaces
         missing_padding = '=' * (-len(raw_data) % 4)
         if missing_padding:
             raw_data += missing_padding
@@ -73,6 +80,7 @@ def parse(uri):
         # Note: unquote_to_bytes() does not raise exceptions for invalid
         # or partial escapes, so there is no error handling here.
         data = urllib.parse.unquote_to_bytes(raw_data)
+
     if not media_type:
         media_type = None
     return ParsedDataURI(media_type, data, uri)

--- a/datauri/datauri.py
+++ b/datauri/datauri.py
@@ -53,6 +53,8 @@ def parse(uri, strict=True):
 
     Returns a ParsedDataURI instance.
     """
+    if not strict:
+        uri = uri.lstrip()
     if not uri.startswith('data:'):
         raise DataURIError('invalid data uri')
     s = uri[5:]

--- a/datauri/datauri.py
+++ b/datauri/datauri.py
@@ -8,9 +8,9 @@ import urllib.parse
 RE_DATA_URI = re.compile(
     'data:[{unreserved}{reserved}{percent}]+'
     .format(
-        unreserved="A-Za-z0-9-_.~",
-        reserved=":/?#\[\]@!$&'()*+,;=",  # only square brackets are escaped
-        percent='%'))
+        unreserved=r"A-Za-z0-9-_.~",
+        reserved=r":/?#\[\]@!$&'()*+,;=",  # only square brackets are escaped
+        percent=r'%'))
 
 
 class DataURIError(ValueError):

--- a/tests/test_datauri.py
+++ b/tests/test_datauri.py
@@ -38,6 +38,19 @@ def test_parse_base64_with_missing_padding():
     assert parsed.data == b'any carnal pleasur'
 
 
+# https://github.com/eclecticiq/python-data-uri/issues/7
+@pytest.mark.parametrize('data', [
+    'data:text/plain;base64, YW55IGNhcm5hbCBwbGVhcw',
+    'data:text/plain;base64,YW55IGNhcm5hbCBwbGVhcw  ',
+    'data:text/plain;base64,\tYW55IGNhcm5hbCBwbGVhcw',
+    'data: text/plain; base64,YW55IGNhcm5hbCBwbGVhcw',
+    'data: text/plain; charset=whatever,any carnal pleas',
+])
+def test_parse_base64_with_space(data):
+    parsed = datauri.parse(data, strict=False)
+    assert parsed.data == b'any carnal pleas'
+
+
 def test_parse_invalid():
     invalid_inputs = [
         '',

--- a/tests/test_datauri.py
+++ b/tests/test_datauri.py
@@ -42,8 +42,10 @@ def test_parse_base64_with_missing_padding():
 @pytest.mark.parametrize('data', [
     'data:text/plain;base64, YW55IGNhcm5hbCBwbGVhcw',
     'data:text/plain;base64,YW55IGNhcm5hbCBwbGVhcw  ',
+    'data:text/plain;base64,YW55IGNhcm 5hbCBwbGVhcw',
     'data:text/plain;base64,\tYW55IGNhcm5hbCBwbGVhcw',
     'data: text/plain; base64,YW55IGNhcm5hbCBwbGVhcw',
+    '  data:text/plain;base64,YW55IGNhcm5hbCBwbGVhcw',
     'data: text/plain; charset=whatever,any carnal pleas',
 ])
 def test_parse_base64_with_space(data):


### PR DESCRIPTION
Add `strict=False` mode to drop all possible whitespaces. Close #7. As discussed in #8, the library remains strict by default.