### PR TITLE
Fix SyntaxWarning on regex - use a raw string

### DIFF
--- a/datauri/datauri.py
+++ b/datauri/datauri.py
@@ -9,7 +9,7 @@ RE_DATA_URI = re.compile(
     'data:[{unreserved}{reserved}{percent}]+'
     .format(
         unreserved="A-Za-z0-9-_.~",
-        reserved=":/?#\[\]@!$&'()*+,;=",  # only square brackets are escaped
+        reserved=r":/?#\[\]@!$&'()*+,;=",  # only square brackets are escaped
         percent='%'))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33,py34,py35,py36
+envlist = py33,py34,py35,py36,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13,py3.14
 
 [testenv]
 deps=-rrequirements-test.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33,py34,py35,py36,py3.8,py3.9,py3.10,py3.11,py3.12,py3.13,py3.14
+envlist = py3.10,py3.11,py3.12,py3.13,py3.14
 
 [testenv]
 deps=-rrequirements-test.txt


### PR DESCRIPTION
Running under python 3.14 produces a `SyntaxWarning: "\[" is an invalid escape sequence. Such sequences will not work in the future. Did you mean "\\["? A raw string is also an option.`

ref https://docs.python.org/3/library/re.html - this was a `DeprecationWarning` in py3.8-3.9, and a `SyntaxWarning` in 3.10-3.14.

Added python 3.8-3.14 to `tox.ini`, and verified existing tests all pass. They also pass in 3.15.0a6.

Manually verified (pytest + flake8) on Python 3.3 in the "python:3.3.5" docker container image, with packages installed:

        $ pip freeze
        coverage==4.0.3
        flake8==2.5.1
        mccabe==0.3.1
        pep8==1.7.1
        py==1.11.0
        pyflakes==1.0.0
        pytest==2.9.2
        pytest-cov==2.2.0
