### PR TITLE
Add continuous integration - lint and test

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -1,0 +1,41 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+    tags: '*'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: 3.13
+        cache: 'pip'
+        cache-dependency-path: 'requirements-test.txt'
+
+    - uses: astral-sh/ruff-action@v3
+      with:
+        args: "check --verbose"
+
+    - name: mypy
+      run: |
+        pip install mypy
+        mypy --verbose
+
+  test-linux:
+    needs: [linter]
+    uses: asottile/workflows/.github/workflows/tox.yml@v1.8.1
+    with:
+      env: '["py310", "py311", "py312", "py313", "py314"]'
+      os: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
+    hooks:
+    -   id: pyupgrade
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.14.14
+  hooks:
+    - id: ruff-check
+    # Run the formatter.
+    #- id: ruff-format
+    #  args: ['--check', '--diff']
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.19.1
+  hooks:
+  - id: mypy
+    args: [ --verbose ]
+
+# Warning: Ty is currently in preview and not ready for production use. Expect bugs and missing features.
+- repo: https://github.com/allganize/ty-pre-commit
+  rev: v0.0.17
+  hooks:
+  - id: ty-check
+    args: [ --verbose, -v, --output-format=full ]
+
+-   repo: meta
+    hooks:
+    - id: check-hooks-apply
+    - id: check-useless-excludes

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,41 @@
+[mypy]
+# minimum supported version
+python_version = 3.10
+# isolated
+no_site_packages = True
+
+# Don't look insude untyped function definitions
+check_untyped_defs = False
+# Allow untyped function definitions to exist
+disallow_untyped_defs = False
+
+warn_unused_configs = True
+
+# --strict
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+strict_equality = True
+strict_bytes = True
+extra_checks = True
+
+
+show_error_context = True
+show_column_numbers = True
+pretty = True
+
+files = datauri/*.py,tests/test_*.py,setup.py
+
+
+# Don't complain about failing to find these dependencies
+[mypy-setuptools]
+ignore_missing_imports = True
+
+[mypy-pytest]
+ignore_missing_imports = True

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,29 @@
+target-version = "py310"
+indent-width = 3
+
+
+[lint]
+extend-select = [
+    "UP",  # pyupgrade
+    "F",  # flake8
+    "S",  # flake8 bandit
+    # "ANN",  # TODO: require type annotations
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+     # - W605 = invalid-escape-sequence
+     # - W1401 = anomalous-backslash-in-string
+
+    "C901",  # McCabe complexity
+    "ERA001",  # commented out code
+    "N",  # pep8 naming
+    "RUF",  # ruff
+    "PL",
+]
+
+ignore = [
+    "PLR2004",  # 20 byte limit in repr
+    "UP032",  # pyupgrade - Use f-string instead of `format` call (in repr)
+]
+
+[lint.per-file-ignores]
+"tests/**" = ["S101"]  # allow "assert" in tests/ directory

--- a/ty.toml
+++ b/ty.toml
@@ -1,0 +1,14 @@
+[environment]
+# minimum supported version
+python-version = "3.10"
+
+[[overrides]]
+include = ["tests/**", "setup.py"]
+
+[overrides.analysis]
+# Don't complain about failing to find these dependencies
+allowed-unresolved-imports = ["setuptools", "pytest"]
+
+[rules]
+# Note that ty does not have an equivilant to mypy disallow_untyped_defs=True.
+# Instead, that's provided by ruff via flake8-annotations (ANN) rules.


### PR DESCRIPTION
A task to setup Travis-CI has been open since 2017, and Travis-CI ceased to be an option at the end of 2020. Propose to start doing CI with Github Actions.

Static analysis: ruff, mypy, ty

Testing: tox -> pytest

Closes #2